### PR TITLE
Add N03 DBF importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pip install -e .
 - `app/build_database.py` - 任意の CSV 群を 1 つのデータベースにまとめます。
 - `app/import_generic_dbf.py` - 単一の DBF を簡易的に取り込むサンプル。
 - `app/estat/import_r2ka.py` - `doc/estat/R2KA_database_spec.md` のスキーマに従って R2KA 形式の CSV/DBF を取り込みます。
+- `app/import_n03.py` - 国土数値情報 N03 形式の DBF を取り込みます。
 
 ## 使用例
 
@@ -36,6 +37,12 @@ python app/build_database.py CSVディレクトリ 出力.db
 
 ```bash
 python app/import_generic_dbf.py 出力.db data.dbf
+```
+
+### N03 DBF 取り込み
+
+```bash
+python app/import_n03.py 出力.db dev/N03-20240101_33.dbf
 ```
 
 ### R2KA CSV/DBF の取り込み

--- a/app/import_n03.py
+++ b/app/import_n03.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from dbf_utils.database import Database
+from dbf_utils.n03 import N03Importer
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Import N03 DBF into SQLite")
+    p.add_argument("db_path", type=Path, help="SQLite database path")
+    p.add_argument("dbf_file", type=Path, help="N03 DBF file")
+    p.add_argument("--encoding", default="cp932", help="File encoding (default: cp932)")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    with Database(args.db_path) as db:
+        importer = N03Importer(db, encoding=args.encoding)
+        attempted, inserted = importer.import_dbf(str(args.dbf_file))
+        print(f"Processed {attempted} rows, inserted {inserted} cities.")
+        print(f"Database saved to {args.db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dbf_utils/__init__.py
+++ b/src/dbf_utils/__init__.py
@@ -9,6 +9,7 @@ from .r2ka import (
     CodesViewReader,
     R2KAImporter,
 )
+from .n03 import N03Importer
 
 __all__ = [
     "CsvToSqliteConverter",
@@ -23,4 +24,5 @@ __all__ = [
     "SubAreaReader",
     "CodesViewReader",
     "R2KAImporter",
+    "N03Importer",
 ]

--- a/src/dbf_utils/n03/__init__.py
+++ b/src/dbf_utils/n03/__init__.py
@@ -1,0 +1,3 @@
+from .n03_importer import N03Importer
+
+__all__ = ["N03Importer"]

--- a/src/dbf_utils/n03/n03_importer.py
+++ b/src/dbf_utils/n03/n03_importer.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Dict, Iterable, Tuple
+
+from dbfread import DBF
+
+from ..database import Database
+
+
+class N03Importer:
+    """Import municipalities from the MLIT N03 DBF format."""
+
+    def __init__(self, db: Database, encoding: str = "cp932") -> None:
+        self.db = db
+        self.encoding = encoding
+
+    def _create_schema(self, conn: sqlite3.Connection) -> None:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS prefectures (
+                prefecture_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                pref_code INTEGER UNIQUE NOT NULL,
+                pref_name TEXT NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS cities (
+                city_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                pref_code INTEGER NOT NULL REFERENCES prefectures(pref_code),
+                city_code INTEGER NOT NULL,
+                city_name TEXT NOT NULL,
+                UNIQUE(pref_code, city_code)
+            )
+            """
+        )
+        conn.commit()
+
+    def import_dbf(self, path: str) -> tuple[int, int]:
+        """Import a single N03 DBF file.
+
+        Returns a tuple of (records_read, cities_inserted).
+        """
+        table = DBF(path, encoding=self.encoding)
+        conn = self.db.conn
+        self._create_schema(conn)
+        cur = conn.cursor()
+
+        cur.execute("SELECT pref_code, prefecture_id FROM prefectures")
+        pref_cache: Dict[int, int] = {code: pid for code, pid in cur.fetchall()}
+
+        cur.execute("SELECT pref_code, city_code, city_id FROM cities")
+        city_cache: Dict[Tuple[int, int], int] = {
+            (p, c): cid for p, c, cid in cur.fetchall()
+        }
+
+        attempted = 0
+        inserted = 0
+
+        for rec in table:
+            attempted += 1
+            pref_name = str(rec.get("N03_001", "")).strip()
+            city_name = str(rec.get("N03_004", "")).strip()
+            code = str(rec.get("N03_007", "")).strip()
+            if not code.isdigit() or len(code) != 5:
+                # Skip invalid records
+                continue
+            pref_code = int(code[:2])
+            city_code = int(code[2:])
+
+            if pref_code not in pref_cache:
+                cur.execute(
+                    "INSERT INTO prefectures (pref_code, pref_name) VALUES (?, ?)",
+                    (pref_code, pref_name),
+                )
+                pref_cache[pref_code] = cur.lastrowid
+
+            if (pref_code, city_code) not in city_cache:
+                cur.execute(
+                    "INSERT INTO cities (pref_code, city_code, city_name) VALUES (?, ?, ?)",
+                    (pref_code, city_code, city_name),
+                )
+                city_cache[(pref_code, city_code)] = cur.lastrowid
+                inserted += 1
+
+        conn.commit()
+        return attempted, inserted
+
+
+__all__ = ["N03Importer"]

--- a/tests/estat/test_api.py
+++ b/tests/estat/test_api.py
@@ -1,6 +1,8 @@
 import sqlite3
 import tempfile
 from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
 
 from dbf_utils.database import Database
 from dbf_utils.r2ka import (

--- a/tests/estat/test_importer.py
+++ b/tests/estat/test_importer.py
@@ -2,6 +2,8 @@ import sqlite3
 import tempfile
 from pathlib import Path
 import unittest
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
 
 
 from dbf_utils.database import Database

--- a/tests/test_n03.py
+++ b/tests/test_n03.py
@@ -1,0 +1,21 @@
+import tempfile
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+from dbf_utils.database import Database
+from dbf_utils.n03 import N03Importer
+
+
+def test_import_n03_dbf():
+    dbf_path = Path('dev/N03-20240101_33.dbf')
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / 'out.db'
+        with Database(db_path) as db:
+            importer = N03Importer(db, encoding='cp932')
+            attempted, inserted = importer.import_dbf(str(dbf_path))
+            assert attempted > 0
+            assert inserted > 0
+            cur = db.conn.execute('SELECT COUNT(*) FROM cities')
+            count = cur.fetchone()[0]
+            assert count == inserted


### PR DESCRIPTION
## Summary
- add importer for MLIT N03 DBF format
- expose new importer in library and provide command line script
- document new script and example usage
- tests load package without installation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6857988cb438832b95d8775fa06a6008