### PR TITLE
Rename N03 modules to gis_map and adjust CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install -e .
 - `app/build_database.py` - 任意の CSV 群を 1 つのデータベースにまとめます。
 - `app/import_generic_dbf.py` - 単一の DBF を簡易的に取り込むサンプル。
 - `app/estat/import_r2ka.py` - `doc/estat/R2KA_database_spec.md` のスキーマに従って R2KA 形式の CSV/DBF を取り込みます。
-- `app/import_n03.py` - 国土数値情報 N03 形式の DBF を取り込みます。
+- `app/import_gis_map.py` - 国土数値情報 GIS Map 形式の DBF を取り込みます。
 
 ## 使用例
 
@@ -39,10 +39,10 @@ python app/build_database.py CSVディレクトリ 出力.db
 python app/import_generic_dbf.py 出力.db data.dbf
 ```
 
-### N03 DBF 取り込み
+### GIS Map DBF 取り込み
 
 ```bash
-python app/import_n03.py 出力.db dev/N03-20240101_33.dbf
+python app/import_gis_map.py 出力.db dev/N03-20240101_33.dbf
 ```
 
 ### R2KA CSV/DBF の取り込み

--- a/app/import_gis_map.py
+++ b/app/import_gis_map.py
@@ -3,15 +3,20 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import io
+import sys
+
+# Allow running without installing the package
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from dbf_utils.database import Database
-from dbf_utils.n03 import N03Importer
+from dbf_utils.gis_map import GISMapImporter
 
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Import N03 DBF into SQLite")
+    p = argparse.ArgumentParser(description="Import GIS Map DBF into SQLite")
     p.add_argument("db_path", type=Path, help="SQLite database path")
-    p.add_argument("dbf_file", type=Path, help="N03 DBF file")
+    p.add_argument("dbf_file", type=Path, help="GIS Map DBF file")
     p.add_argument("--encoding", default="cp932", help="File encoding (default: cp932)")
     return p.parse_args()
 
@@ -19,8 +24,9 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
     with Database(args.db_path) as db:
-        importer = N03Importer(db, encoding=args.encoding)
-        attempted, inserted = importer.import_dbf(str(args.dbf_file))
+        importer = GISMapImporter(db, encoding=args.encoding)
+        with io.open(args.dbf_file, "rb") as f:
+            attempted, inserted = importer.import_dbf(f.name)
         print(f"Processed {attempted} rows, inserted {inserted} cities.")
         print(f"Database saved to {args.db_path}")
 

--- a/src/dbf_utils/__init__.py
+++ b/src/dbf_utils/__init__.py
@@ -9,7 +9,7 @@ from .r2ka import (
     CodesViewReader,
     R2KAImporter,
 )
-from .n03 import N03Importer
+from .gis_map import GISMapImporter
 
 __all__ = [
     "CsvToSqliteConverter",
@@ -24,5 +24,5 @@ __all__ = [
     "SubAreaReader",
     "CodesViewReader",
     "R2KAImporter",
-    "N03Importer",
+    "GISMapImporter",
 ]

--- a/src/dbf_utils/gis_map/__init__.py
+++ b/src/dbf_utils/gis_map/__init__.py
@@ -1,0 +1,3 @@
+from .gis_map_importer import GISMapImporter
+
+__all__ = ["GISMapImporter"]

--- a/src/dbf_utils/gis_map/gis_map_importer.py
+++ b/src/dbf_utils/gis_map/gis_map_importer.py
@@ -8,8 +8,8 @@ from dbfread import DBF
 from ..database import Database
 
 
-class N03Importer:
-    """Import municipalities from the MLIT N03 DBF format."""
+class GISMapImporter:
+    """Import municipalities from the MLIT GIS Map (formerly N03) DBF format."""
 
     def __init__(self, db: Database, encoding: str = "cp932") -> None:
         self.db = db
@@ -40,7 +40,7 @@ class N03Importer:
         conn.commit()
 
     def import_dbf(self, path: str) -> tuple[int, int]:
-        """Import a single N03 DBF file.
+        """Import a single GIS Map DBF file.
 
         Returns a tuple of (records_read, cities_inserted).
         """
@@ -90,4 +90,4 @@ class N03Importer:
         return attempted, inserted
 
 
-__all__ = ["N03Importer"]
+__all__ = ["GISMapImporter"]

--- a/src/dbf_utils/n03/__init__.py
+++ b/src/dbf_utils/n03/__init__.py
@@ -1,3 +1,0 @@
-from .n03_importer import N03Importer
-
-__all__ = ["N03Importer"]

--- a/tests/test_gis_map.py
+++ b/tests/test_gis_map.py
@@ -4,15 +4,15 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
 
 from dbf_utils.database import Database
-from dbf_utils.n03 import N03Importer
+from dbf_utils.gis_map import GISMapImporter
 
 
-def test_import_n03_dbf():
+def test_import_gis_map_dbf():
     dbf_path = Path('dev/N03-20240101_33.dbf')
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / 'out.db'
         with Database(db_path) as db:
-            importer = N03Importer(db, encoding='cp932')
+            importer = GISMapImporter(db, encoding='cp932')
             attempted, inserted = importer.import_dbf(str(dbf_path))
             assert attempted > 0
             assert inserted > 0


### PR DESCRIPTION
## Summary
- rename `n03` package to `gis_map`
- update importer class to `GISMapImporter`
- add new `app/import_gis_map.py` script
- update references in README and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6857ad463314832b8fa55d7292af2f2e