### PR TITLE
Update view names

### DIFF
--- a/src/dbf_utils/__init__.py
+++ b/src/dbf_utils/__init__.py
@@ -1,9 +1,9 @@
-from .database import Database, create_codes_view, create_cities_view
+from .database import Database, create_codes_view, create_areas_view
 from .gis_map import GISMapImporter
 
 __all__ = [
     "Database",
     "create_codes_view",
-    "create_cities_view",
+    "create_areas_view",
     "GISMapImporter",
 ]

--- a/src/dbf_utils/database.py
+++ b/src/dbf_utils/database.py
@@ -35,8 +35,8 @@ def create_codes_view(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
-def create_cities_view(conn: sqlite3.Connection) -> None:
-    """Create ``cities_view`` if required tables are present."""
+def create_areas_view(conn: sqlite3.Connection) -> None:
+    """Create ``areas_view`` if required tables are present."""
     required = [
         'cities',
         'subprefecters',
@@ -47,10 +47,11 @@ def create_cities_view(conn: sqlite3.Connection) -> None:
         return
     conn.execute(
         """
-        CREATE VIEW IF NOT EXISTS cities_view AS
+        CREATE VIEW IF NOT EXISTS areas_view AS
         SELECT
             c.city_id AS city_id,
             c.pref_code AS pref_code,
+            c.city_code AS city_code,
             sp.subpref_name AS subpref_name,
             d.distinct_name AS distinct_name,
             c.city_name AS city_name,
@@ -82,4 +83,4 @@ class Database:
         self.close()
 
 
-__all__ = ["Database", "create_codes_view", "create_cities_view"]
+__all__ = ["Database", "create_codes_view", "create_areas_view"]

--- a/src/dbf_utils/gis_map/gis_map_importer.py
+++ b/src/dbf_utils/gis_map/gis_map_importer.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterable, Tuple
 
 from ..dbf import parse_dbf
 
-from ..database import Database, create_cities_view
+from ..database import Database, create_areas_view
 
 
 class GISMapImporter:
@@ -65,7 +65,7 @@ class GISMapImporter:
             """
         )
         conn.commit()
-        create_cities_view(conn)
+        create_areas_view(conn)
 
     def import_dbf(self, path: str) -> tuple[int, int]:
         """Import a single GIS Map DBF file.

--- a/tests/estat/test_api.py
+++ b/tests/estat/test_api.py
@@ -2,7 +2,7 @@ import sqlite3
 import tempfile
 from pathlib import Path
 import sys
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src'))
 
 from dbf_utils.database import Database
 from dbf_utils.r2ka import (

--- a/tests/estat/test_importer.py
+++ b/tests/estat/test_importer.py
@@ -3,7 +3,7 @@ import tempfile
 from pathlib import Path
 import unittest
 import sys
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src'))
 
 
 from dbf_utils.database import Database

--- a/tests/test_gis_map.py
+++ b/tests/test_gis_map.py
@@ -31,10 +31,10 @@ def test_import_gis_map_dbf():
             assert 'ward_id' in cols
 
             cur = db.conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='view' AND name='cities_view'"
+                "SELECT name FROM sqlite_master WHERE type='view' AND name='areas_view'"
             )
             assert cur.fetchone() is not None
             cur = db.conn.execute(
-                'SELECT city_id, pref_code, subpref_name, distinct_name, city_name, ward_name FROM cities_view LIMIT 1'
+                'SELECT city_id, pref_code, city_code, subpref_name, distinct_name, city_name, ward_name FROM areas_view LIMIT 1'
             )
             cur.fetchall()


### PR DESCRIPTION
## Summary
- rename view and API from `names_view` to `areas_view`
- include `pref_code` and `city_code` columns in the new view
- adjust GIS map importer to create the new view
- update tests to verify the new structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859d085d8d8832b931ed197eb4a8133